### PR TITLE
Upgrade the examples to a recent version of riscv.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,7 +4,7 @@
 
 [target.riscv64gc-unknown-none-elf]
 #runner = "riscv64-unknown-elf-gdb -x gdb_init"
-runner = "../k210-run --flash"
+runner = "bash ../k210-run.sh --flash"
 rustflags = [
   "-C", "link-arg=-Tmemory.x",
   "-C", "link-arg=-Tlink.x",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ panic-halt = "0.2.0"
 riscv = "0.10"
 riscv-rt = "0.11"
 k210-pac = {git = "https://github.com/alexistm/k210-pac", branch = "feature/svd_0_28_0", features = ["critical"]}
-k210-hal = "0.2"
+k210-hal = {path = "../k210-hal"}
+# k210-hal = {git = "https://github.com/alexistm/k210-hal", branch = "feature/svd_0_28_0"}
 embedded-hal = "0.2"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,14 @@ edition = "2018"
 
 [dependencies]
 panic-halt = "0.2.0"
-riscv = "0.6.0"
-riscv-rt = "0.8.0"
-k210-hal = "0.2.0"
+riscv = "0.10"
+riscv-rt = "0.11"
+k210-pac = {git = "https://github.com/alexistm/k210-pac", branch = "upgrade/v0.10.0", features = ["critical"]}
+k210-hal = "0.2"
+embedded-hal = "0.2"
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k210-example"
-version = "0.1.1"
+version = "0.3.0"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 edition = "2018"
 
@@ -8,7 +8,7 @@ edition = "2018"
 panic-halt = "0.2.0"
 riscv = "0.10"
 riscv-rt = "0.11"
-k210-pac = {git = "https://github.com/alexistm/k210-pac", branch = "upgrade/v0.10.0", features = ["critical"]}
+k210-pac = {git = "https://github.com/alexistm/k210-pac", branch = "feature/svd_0_28_0", features = ["critical"]}
 k210-hal = "0.2"
 embedded-hal = "0.2"
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 This project is developed and maintained by the [RISC-V team][team].
 
+## Building
+
+```
+rustup target add riscv64gc-unknown-none-elf
+rustup +nightly target add riscv64gc-unknown-none-elf
+
+cargo build --examples
+cargo +nightly build --examples # for examples with interrupts
+```
+
 ## Getting started
 
 Start openocd:

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,15 @@
-use std::{env, fs};
-use std::path::PathBuf;
 use std::io::Write;
+use std::path::PathBuf;
+use std::{env, fs};
 
 fn main() {
     // Put the linker script somewhere the linker can find it
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     println!("cargo:rustc-link-search={}", out_dir.display());
 
-    fs::File::create(out_dir.join("memory.x")).unwrap()
-        .write_all(include_bytes!("memory.x")).unwrap();
+    fs::File::create(out_dir.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
     println!("cargo:rerun-if-changed=memory.x");
 }

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -13,6 +13,7 @@ fn main() -> ! {
     let mut sysctl = p.SYSCTL.constrain();
     let fpioa = p.FPIOA.split(&mut sysctl.apb0);
     let gpio = p.GPIO.split(&mut sysctl.apb0);
+
     let io12 = fpioa.io12.into_function(fpioa::GPIO7);
     let io13 = fpioa.io13.into_function(fpioa::GPIO5);
     let io14 = fpioa.io14.into_function(fpioa::GPIO6);
@@ -33,10 +34,10 @@ fn main() -> ! {
 
             red.toggle().unwrap();
             if i % 2 == 0 {
-              green.toggle().unwrap();
+                green.toggle().unwrap();
             }
             if i % 3 == 0 {
-              blue.toggle().unwrap();
+                blue.toggle().unwrap();
             }
 
             i += 1;

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,20 +1,22 @@
 #![no_std]
 #![no_main]
 
+use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::v2::ToggleableOutputPin;
+use k210_hal::{fpioa, gpio::Gpio, pac, prelude::*};
 use panic_halt as _;
-use k210_hal::{prelude::*, fpioa, pac, gpio::Gpio};
 
 #[riscv_rt::entry]
 fn main() -> ! {
-    let p = pac::Peripherals::take().unwrap();
-    
+    let p = unsafe { pac::Peripherals::steal() };
+
     let mut sysctl = p.SYSCTL.constrain();
     let fpioa = p.FPIOA.split(&mut sysctl.apb0);
     let gpio = p.GPIO.split(&mut sysctl.apb0);
     let io14 = fpioa.io14.into_function(fpioa::GPIO6);
     let mut blue = Gpio::new(gpio.gpio6, io14).into_push_pull_output();
 
-    blue.try_set_low().ok();
+    blue.set_low().unwrap();
 
     let mut last_update = riscv::register::mcycle::read();
     loop {
@@ -22,7 +24,7 @@ fn main() -> ! {
         if cur - last_update >= 100_000_000 {
             last_update = cur;
 
-            blue.try_toggle().ok();
+            blue.toggle().unwrap();
         }
     }
 }

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -13,18 +13,33 @@ fn main() -> ! {
     let mut sysctl = p.SYSCTL.constrain();
     let fpioa = p.FPIOA.split(&mut sysctl.apb0);
     let gpio = p.GPIO.split(&mut sysctl.apb0);
+    let io12 = fpioa.io12.into_function(fpioa::GPIO7);
+    let io13 = fpioa.io13.into_function(fpioa::GPIO5);
     let io14 = fpioa.io14.into_function(fpioa::GPIO6);
+    let mut green = Gpio::new(gpio.gpio7, io12).into_push_pull_output();
+    let mut red = Gpio::new(gpio.gpio5, io13).into_push_pull_output();
     let mut blue = Gpio::new(gpio.gpio6, io14).into_push_pull_output();
 
-    blue.set_low().unwrap();
+    red.set_high().unwrap();
+    green.set_high().unwrap();
+    blue.set_high().unwrap();
 
     let mut last_update = riscv::register::mcycle::read();
+    let mut i = 0;
     loop {
         let cur = riscv::register::mcycle::read();
         if cur - last_update >= 100_000_000 {
             last_update = cur;
 
-            blue.toggle().unwrap();
+            red.toggle().unwrap();
+            if i % 2 == 0 {
+              green.toggle().unwrap();
+            }
+            if i % 3 == 0 {
+              blue.toggle().unwrap();
+            }
+
+            i += 1;
         }
     }
 }

--- a/examples/gpio-console.rs
+++ b/examples/gpio-console.rs
@@ -1,17 +1,17 @@
 #![no_std]
 #![no_main]
 
+use k210_hal::{fpioa, gpio::Gpio, pac, prelude::*, stdout::Stdout};
 use panic_halt as _;
-use k210_hal::{prelude::*, fpioa, pac, gpio::Gpio, stdout::Stdout};
 
 #[riscv_rt::entry]
 fn main() -> ! {
-    let p = pac::Peripherals::take().unwrap();
+    let p = unsafe { pac::Peripherals::steal() };
 
     let mut sysctl = p.SYSCTL.constrain();
     let fpioa = p.FPIOA.split(&mut sysctl.apb0);
     let gpio = p.GPIO.split(&mut sysctl.apb0);
-    let gpiohs = p.GPIOHS.split();
+    let _gpiohs = p.GPIOHS.split();
 
     // Configure clocks (TODO)
     let clocks = k210_hal::clock::Clocks::new();
@@ -20,31 +20,30 @@ fn main() -> ! {
     let _uarths_tx = fpioa.io5.into_function(fpioa::UARTHS_TX);
 
     // let boot_button = Gpio::new(
-    //     gpio.gpio2, 
+    //     gpio.gpio2,
     //     fpioa.io16.into_function(fpioa::GPIO2)
     // ).into_pull_up_input();
     let io14 = fpioa.io14.into_function(fpioa::GPIO6);
-    let mut blue = Gpio::new(gpio.gpio6, io14).into_push_pull_output();
+    let mut _blue = Gpio::new(gpio.gpio6, io14).into_push_pull_output();
 
     // Configure UART
-    let serial = p.UARTHS.configure(
-        115_200.bps(), 
-        &clocks
-    );
+    let serial = p.UARTHS.configure(115_200.bps(), &clocks);
     let (mut tx, _rx) = serial.split();
 
     let mut stdout = Stdout(&mut tx);
 
     writeln!(stdout, "Hello, Rust!").ok();
 
-    unsafe { &*pac::GPIO::ptr() }.source.write(|w| unsafe { w.bits(0xaa) });
+    unsafe { &*pac::GPIO::ptr() }
+        .source
+        .write(|w| unsafe { w.bits(0xaa) });
     loop {
         for i in 8..16 {
             let io = unsafe { &*pac::FPIOA::ptr() }.io[i].read();
-            writeln!(stdout, 
+            writeln!(stdout,
                 "[{}] CH {}, DS {:02X}, OE {}, OEI {}, DO {}, DOI {}, PU {}, PD {}, SL {}, IE {}, IEI {}, DII {}, ST {}, PA {}",
                 i, io.ch_sel().bits(), io.ds().bits(), io.oe_en().bit(), io.oe_inv().bit(),
-                io.do_sel().bit(), io.do_inv().bit(), io.pu().bit(), io.pd().bit(), 
+                io.do_sel().bit(), io.do_inv().bit(), io.pu().bit(), io.pd().bit(),
                 io.sl().bit(), io.ie_en().bit(), io.ie_inv().bit(), io.di_inv().bit(), io.st().bit(), io.pad_di().bit()
             ).ok();
         }
@@ -54,9 +53,11 @@ fn main() -> ! {
         let data_input = unsafe { &*pac::GPIO::ptr() }.data_input.read().bits();
         let sync_level = unsafe { &*pac::GPIO::ptr() }.sync_level.read().bits();
         let id_code = unsafe { &*pac::GPIO::ptr() }.id_code.read().bits();
-        writeln!(stdout, 
+        writeln!(
+            stdout,
             "O {:08b}, D {:08b}, S {:08b}, I {:08b}, SY {:08b}, ID 0x{:08X}",
             data_output, direction, source, data_input, sync_level, id_code
-        ).ok();
+        )
+        .ok();
     }
 }

--- a/examples/i2s_reading.rs
+++ b/examples/i2s_reading.rs
@@ -1,0 +1,93 @@
+#![no_std]
+#![no_main]
+
+use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::v2::ToggleableOutputPin;
+use k210_hal::sysctl;
+use k210_hal::time::Hertz;
+use k210_hal::{fpioa, gpio::Gpio, i2s, pac, prelude::*};
+use pac::SYSCTL;
+use panic_halt as _;
+
+#[riscv_rt::entry]
+fn main() -> ! {
+    let p = unsafe { pac::Peripherals::steal() };
+
+    let mut sysctl = p.SYSCTL.constrain();
+    let fpioa = p.FPIOA.split(&mut sysctl.apb0);
+    let gpio = p.GPIO.split(&mut sysctl.apb0);
+    let io12 = fpioa.io12.into_function(fpioa::GPIO7);
+    let io11 = fpioa.io11.into_function(fpioa::GPIO5);
+    let io10 = fpioa.io10.into_function(fpioa::GPIO6);
+    let mut green = Gpio::new(gpio.gpio7, io12).into_push_pull_output();
+    let mut red = Gpio::new(gpio.gpio5, io11).into_push_pull_output();
+    let mut blue = Gpio::new(gpio.gpio6, io10).into_push_pull_output();
+
+    // SW SPI?
+    let gpiohs27 = fpioa.io13.into_function(fpioa::GPIOHS27);
+    let gpiohs28 = fpioa.io14.into_function(fpioa::GPIOHS28);
+
+    // IO for embedded mic
+    let io18 = fpioa.io18.into_function(fpioa::I2S0_SCLK);
+    let io19 = fpioa.io19.into_function(fpioa::I2S0_WS);
+    let io20 = fpioa.io20.into_function(fpioa::I2S0_IN_D3);
+
+    // IO for mic array
+    // let io22 = fpioa.io22.into_function(fpioa::I2S0_SCLK);
+    // let io21 = fpioa.io21.into_function(fpioa::I2S0_WS);
+    // let io32 = fpioa.io32.into_function(fpioa::I2S0_IN_D0);
+    // let io15 = fpioa.io15.into_function(fpioa::I2S0_IN_D1);
+    // let io23 = fpioa.io23.into_function(fpioa::I2S0_IN_D2);
+    // let io24 = fpioa.io24.into_function(fpioa::I2S0_IN_D3);
+
+    let i2s0 = i2s::I2s::new(p.I2S0, &mut sysctl.pll2);
+    i2s0.set_rx_word_length(i2s::WordLength::Resolution16Bit);
+    i2s0.set_sample_rate(Hertz(44_000));
+    i2s0.configure_master(
+        i2s::WordSelectCycle::SclkCycles24,
+        i2s::GatingCycles::ClockCycles16,
+        i2s::AlignMode::StandardMode,
+    );
+    /*
+       from Maix import MIC_ARRAY as mic
+       import lcd
+
+       lcd.init()
+       mic.init()
+       # reconfigure pins after mic.init() to match your wiring
+
+       while True:
+           imga = mic.get_map()
+           b = mic.get_dir(imga)
+           a = mic.set_led(b,(0,0,255))
+           imgb = imga.resize(240,160)
+           imgc = imgb.to_rainbow(1)
+           a = lcd.display(imgc)
+       mic.deinit()
+    */
+
+    red.set_high().unwrap();
+    green.set_high().unwrap();
+    blue.set_high().unwrap();
+
+    //i2s_
+
+    let mut last_update = riscv::register::mcycle::read();
+    let mut i = 0;
+    loop {
+        let cur = riscv::register::mcycle::read();
+        if cur - last_update >= 100_000_000 {
+            last_update = cur;
+
+            red.toggle().unwrap();
+            if i % 2 == 0 {
+                green.toggle().unwrap();
+            }
+            if i % 3 == 0 {
+                blue.toggle().unwrap();
+            }
+
+            i += 1;
+        }
+    }
+}

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -118,7 +118,7 @@ fn main() -> ! {
 #[export_name = "_mp_hook"]
 pub fn user_mp_hook() -> bool {
     use riscv::asm::wfi;
-    use riscv::register::mip;    /*}*/
+    use riscv::register::mip; /*}*/
 
     let hart_id = mhartid::read();
     if hart_id == 0 {

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -118,7 +118,7 @@ fn main() -> ! {
 #[export_name = "_mp_hook"]
 pub fn user_mp_hook() -> bool {
     use riscv::asm::wfi;
-    use riscv::register::mip; /*}*/;
+    use riscv::register::mip;    /*}*/
 
     let hart_id = mhartid::read();
     if hart_id == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,16 @@
 #![no_std]
 #![no_main]
 
-use panic_halt as _;
-use k210_hal::prelude::*;
 use k210_hal::fpioa;
-use k210_hal::pac as pac;
+use k210_hal::pac;
+use k210_hal::prelude::*;
 use k210_hal::stdout::Stdout;
+use panic_halt as _;
+use riscv_rt;
 
 #[riscv_rt::entry]
 fn main() -> ! {
-    let p = pac::Peripherals::take().unwrap();
+    let p = unsafe { pac::Peripherals::steal() };
     let mut sysctl = p.SYSCTL.constrain();
     // Prepare pins for UARTHS
     let fpioa = p.FPIOA.split(&mut sysctl.apb0);
@@ -20,10 +21,7 @@ fn main() -> ! {
     let clocks = k210_hal::clock::Clocks::new();
 
     // Configure UART
-    let serial = p.UARTHS.configure(
-        115_200.bps(), 
-        &clocks
-    );
+    let serial = p.UARTHS.configure(115_200.bps(), &clocks);
     let (mut tx, _) = serial.split();
 
     // todo: new stdout design (simple Write impl?)


### PR DESCRIPTION
Bump all libraries to the latest version, including the regenerated version of k210-pac. 

This depends on: https://github.com/riscv-rust/k210-pac/pull/39

This has been tested with the blinky example on a MaixPy board with success.

I will update the k210-crates repo once both PRs are merged, to avoid dangling submodules (like the state it currently is in)